### PR TITLE
[DM-24635] Overhaul authentication challenges

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,29 @@
 Change log
 ##########
 
+1.1.0 (2020-04-28)
+==================
+
+This release overhauls configuration parsing and removes use of Dynaconf.
+As a result, the top-level environment key in configuration files is no longer required (or supported).
+All configuration settings should now be at the top level.
+
+This release also adds support for specifying the type of authentication challenges to unauthenticated users.
+
+- Replace Dyanconf with pydantic for configuration parsing.
+  This should produce much better diagnostics for invalid configuration files.
+  This also eliminates the Dynaconf environment key that was previously expected to be the top-level key of the configuration file.
+  Existing configuration files will need to be flattened by removing that key and elevating configuration settings to the top level.
+- Add support for an ``auth_type`` parameter to the ``/auth`` route.
+  This can be set to ``basic`` to request that unauthenticated users be challenged for Basic authentication instead of Bearer.
+  That in turn will cause pop-up authentication prompting in a web browser.
+- Fix syntax of ``WWW-Authenticate`` challenges and return them in more cases.
+  Attempt to properly implement RFC 6750, including using proper ``error`` attributes, including challenges in some 400 and 403 replies, and including the ``scope`` attribute where appropriate.
+- Return 403 instead of 401 for unauthenticated AJAX requests.
+  401 triggers the redirect handling in ingress-nginx, but this is pointless for AJAX requests, which cannot navigate the redirect to an external authentication provider.
+  Worse, AJAX requests may be frequently retried on error (such as an expired credential), which if redirected can create a low-grade denial of service attack on the authentication provider, trigger rate limiting, and cause other issues.
+  AJAX requests, as detected by ``X-Requested-With: XMLHttpRequest`` in the request headers, now get a 403 reply if they have missing or expired credentials.
+
 1.0.0 (2020-04-24)
 ==================
 

--- a/docs/arch/references.rst
+++ b/docs/arch/references.rst
@@ -1,0 +1,48 @@
+##########
+References
+##########
+
+The following references are helpful when making changes to Gafaelfawr:
+
+`CILogon OpenID Connect`__
+    Documentation for how to use CILogon as an OpenID Connect provider.
+    Includes client registration and the details of the OpenID Connect protocol as implemented by CILogon.
+
+__ https://www.cilogon.org/oidc
+
+`GitHub OAuth Apps`__
+    How to create an OAuth App for GitHub, request authentication, and parse the results.
+
+__ https://developer.github.com/apps/building-oauth-apps/
+
+`GitHub Users API`__
+    APIs for retrieving information about the authenticated user.
+    See also `user emails <https://developer.github.com/v3/users/emails/>`__ and `teams <https://developer.github.com/v3/teams/>`__.
+
+__ https://developer.github.com/v3/users/
+
+`OpenID Connect Core 1.0`__
+    The core specification of the OpenID Connect protocol.
+
+__ https://openid.net/specs/openid-connect-core-1_0.html
+
+`RFC 7517: JSON Web Key (JWK)`__
+    The specification of the JSON Web Key format, including JSON Web Key Sets (JWKS).
+
+__ https://tools.ietf.org/html/rfc7517
+
+`RFC 7519: JSON Web Token (JWT)`__
+    The core specification for the JSON Web Token format.
+
+__ https://tools.ietf.org/html/rfc7519
+
+`RFC 6750: Bearer Token Usage`__
+    Documents the syntax for ``WWW-Authenticate`` and ``Authorization`` header fields when using bearer tokens.
+    The attributes returned in a challenge in a ``WWW-Authenticate`` header field are defined here.
+
+__ https://tools.ietf.org/html/rfc6750
+
+`RFC 7617: The Basic HTTP Authentication Scheme`__
+    Documents the syntax for ``WWW-Authenticate`` and ``Authorization`` header fields when using HTTP Basic Authentication.
+
+__ https://tools.ietf.org/html/rfc7617

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,6 +37,7 @@ Architecture
    arch/providers
    arch/session
    arch/security
+   arch/references
 
 Development guide
 =================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -178,6 +178,17 @@ It will find the user's authentication token, check that it is valid, and check 
 If the user is not authenticated, they will be redirected to the sign-in URL configured here, which in turn will either send the user to CILogon or to GitHub to authenticate.
 If the user is already authenticated but does not have the desired scope, they will receive a 403 error.
 
+The typical annotations for a API that expects direct requests from programs are:
+
+.. code-block:: yaml
+
+   annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Token
+    nginx.ingress.kubernetes.io/auth-url: "https://<hostname>/auth?scope=<scope>"
+
+The difference in this case is that the 401 error when authentication is not provided will be returned to the client, rather than returning a redirect to the login page.
+
 If the user authenticates and authorizes successfully, the request will be sent to the application.
 Included in the request will be an ``X-Auth-Request-Token`` header containing the user's JWT.
 This will be a reissued token signed by Gafaelfawr.
@@ -200,6 +211,11 @@ The URL in the ``nginx.ingress.kubernetes.io/auth-url`` annotation accepts sever
     How to interpret multiple ``scope`` parameters.
     If set to ``all`` (or unset), the user's token must have all of the given scopes.
     If set to ``any``, the user's token must have one of the given scopes.
+
+``auth_type`` (optional)
+    Controls the authentication type in the challenge returned in ``WWW-Authenticate`` if the user is not authenticated.
+    By default, this is ``bearer``.
+    Applications that want to prompt for HTTP Basic Authentication should set this to ``basic`` instead.
 
 ``audience`` (optional)
     May be set to the value of the ``issuer.aud.internal`` configuration parameter, in which case a new token will be issued from the user's token with all the same claims but with that audience.

--- a/src/gafaelfawr/handlers/auth.py
+++ b/src/gafaelfawr/handlers/auth.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import base64
 from typing import TYPE_CHECKING
 
 from aiohttp import web
+from aiohttp_session import get_session
 
 from gafaelfawr.handlers import routes
-from gafaelfawr.handlers.util import authenticated
+from gafaelfawr.handlers.util import (
+    AuthChallenge,
+    AuthError,
+    AuthType,
+    InvalidTokenException,
+    verify_token,
+)
 from gafaelfawr.session import SessionHandle
 
 if TYPE_CHECKING:
@@ -15,14 +23,23 @@ if TYPE_CHECKING:
     from gafaelfawr.factory import ComponentFactory
     from gafaelfawr.tokens import VerifiedToken
     from logging import Logger
-    from typing import Dict
+    from typing import Dict, Optional
 
 __all__ = ["get_auth"]
 
 
+class InvalidRequestException(Exception):
+    """The provided Authorization header could not be parsed.
+
+    This corresponds to the ``invalid_request`` error in RFC 6750: "The
+    request is missing a required parameter, includes an unsupported parameter
+    or parameter value, repeats the same parameter, uses more than one method
+    for including an access token, or is otherwise malformed."
+    """
+
+
 @routes.get("/auth")
-@authenticated
-async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
+async def get_auth(request: web.Request) -> web.Response:
     """Authenticate and authorize a token.
 
     Parameters
@@ -50,6 +67,9 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
     satisfy (optional)
         Require that ``all`` (the default) or ``any`` of the scopes requested
         via the ``scope`` parameter be satisfied.
+    auth_type (optional)
+        The authentication type to use in challenges.  If given, must be
+        either ``bearer`` or ``basic``.  Defaults to ``bearer``.
     audience (optional)
         May be set to the internal audience to request token reissuance.
 
@@ -89,10 +109,11 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
     WWW-Authenticate
         If the request is unauthenticated, this header will be set.
     """
+    config: Config = request.config_dict["gafaelfawr/config"]
     logger: Logger = request["safir/logger"]
 
-    # Determine the required scopes and authorization strategy from the
-    # request.
+    # Determine the required scopes, authorization strategy, and desired auth
+    # type for challenges from the request.
     required_scopes = request.query.getall("scope", [])
     if not required_scopes:
         msg = "scope parameter not set in the request"
@@ -101,6 +122,39 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
     if satisfy not in ("any", "all"):
         msg = "satisfy parameter must be any or all"
         raise web.HTTPBadRequest(reason=msg, text=msg)
+    auth_type_name = request.query.get("auth_type", "bearer")
+    if auth_type_name not in ("basic", "bearer"):
+        msg = "auth_type parameter must be basic or bearer"
+        raise web.HTTPBadRequest(reason=msg, text=msg)
+    auth_type = AuthType[auth_type_name.capitalize()]
+
+    # Check authentication and return an appropriate challenge and error
+    # status if authentication failed.
+    try:
+        token = await get_token_from_request(request)
+        if not token:
+            logger.info("No token found, returning unauthorized")
+            challenge = AuthChallenge(auth_type=auth_type, realm=config.realm)
+            raise unauthorized(request, challenge, "Authentication required")
+    except InvalidRequestException as e:
+        logger.warning("Invalid Authorization header: %s", str(e))
+        challenge = AuthChallenge(
+            auth_type=auth_type,
+            realm=config.realm,
+            error=AuthError.invalid_request,
+            error_description=str(e),
+        )
+        headers = {"WWW-Authenticate": challenge.as_header()}
+        raise web.HTTPBadRequest(headers=headers, reason=str(e), text=str(e))
+    except InvalidTokenException as e:
+        logger.warning("Invalid token: %s", str(e))
+        challenge = AuthChallenge(
+            auth_type=auth_type,
+            realm=config.realm,
+            error=AuthError.invalid_token,
+            error_description=str(e),
+        )
+        raise unauthorized(request, challenge, str(e))
 
     # Determine whether the request is authorized.
     if satisfy == "any":
@@ -108,7 +162,9 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
     else:
         authorized = all([scope in token.scope for scope in required_scopes])
 
-    # If not authorized, log and raise the appropriate error.
+    # If not authorized, log and raise the appropriate error.  Here, we always
+    # return a 403 and include the desired scope in the resulting challenge,
+    # since that may be useful for debugging issues.
     if not authorized:
         logger.error(
             "Token %s (user: %s, scope: %s) not authorized (needed %s of %s)",
@@ -119,7 +175,15 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
             ", ".join(sorted(required_scopes)),
         )
         error = "Missing required scope"
-        raise web.HTTPForbidden(reason=error, text=error)
+        challenge = AuthChallenge(
+            auth_type=auth_type,
+            realm=config.realm,
+            error=AuthError.insufficient_scope,
+            error_description=error,
+            scope=" ".join(sorted(required_scopes)),
+        )
+        headers = {"WWW-Authenticate": challenge.as_header()}
+        raise web.HTTPForbidden(headers=headers, reason=error, text=error)
 
     # Log and return the results.
     logger.info(
@@ -133,6 +197,178 @@ async def get_auth(request: web.Request, token: VerifiedToken) -> web.Response:
     token = maybe_reissue_token(request, token)
     headers = build_success_headers(request, token)
     return web.Response(headers=headers, text="ok")
+
+
+async def get_token_from_request(
+    request: web.Request,
+) -> Optional[VerifiedToken]:
+    """From the request, find the token we need.
+
+    It may be in the session cookie or in an ``Authorization`` header, and the
+    ``Authorization`` header may use type ``Basic`` (of various types) or
+    ``Bearer``.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+
+    Returns
+    -------
+    token : `gafaelfawr.tokens.VerifiedToken`, optional
+        The token if found, otherwise None.
+
+    Raises
+    ------
+    InvalidRequestException
+        The Authorization header was malformed.
+    gafaelfawr.handlers.util.InvalidTokenException
+        A token was provided but it could not be verified.
+    """
+    factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
+    logger: Logger = request["safir/logger"]
+
+    # Use the session cookie if it is available.  This check has to be before
+    # checking the Authorization header, since JupyterHub will set its own
+    # Authorization header in its AJAX calls but we won't be able to extract a
+    # token from that and will return 400 for them.
+    session = await get_session(request)
+    handle_str = session.get("handle")
+    if handle_str:
+        logger.debug("Found valid handle in session")
+        handle = SessionHandle.from_str(handle_str)
+        session_store = factory.create_session_store(request)
+        auth_session = await session_store.get_session(handle)
+        if auth_session:
+            return auth_session.token
+
+    # No session or existing authentication header.  Try the Authorization
+    # header.  This case is used by API calls from clients.  If we got a
+    # session handle, convert it to a token.  Otherwise, if we got a token,
+    # verify it.
+    handle_or_token = parse_authorization(request)
+    if not handle_or_token:
+        return None
+    elif handle_or_token.startswith("gsh-"):
+        handle = SessionHandle.from_str(handle_or_token)
+        session_store = factory.create_session_store(request)
+        auth_session = await session_store.get_session(handle)
+        return auth_session.token if auth_session else None
+    else:
+        return verify_token(request, handle_or_token)
+
+
+def parse_authorization(request: web.Request) -> Optional[str]:
+    """Find a handle or token in the Authorization header.
+
+    Supports either ``Bearer`` or ``Basic`` authorization types.
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+
+    Returns
+    -------
+    handle_or_token : `str` or `None`
+        The handle or token if one was found, otherwise None.
+
+    Raises
+    ------
+    InvalidRequestException
+        If the Authorization header is malformed.
+
+    Notes
+    -----
+    A Basic Auth authentication string is normally a username and a password
+    separated by colon and then base64-encoded.  Support a username of the
+    token (or session handle) and a password of ``x-oauth-basic``, or a
+    username of ``x-oauth-basic`` and a password of the token (or session
+    handle).  If neither is the case, assume the token or session handle is
+    the username.
+    """
+    logger: Logger = request["safir/logger"]
+
+    # Parse the header and handle Bearer.
+    header = request.headers.get("Authorization")
+    if not header:
+        return None
+    if " " not in header:
+        raise InvalidRequestException("malformed Authorization header")
+    auth_type, auth_blob = header.split(" ")
+    if auth_type.lower() == "bearer":
+        return auth_blob
+    elif auth_type.lower() != "basic":
+        msg = f"unkonwn Authorization type {auth_type}"
+        raise InvalidRequestException(msg)
+
+    # Basic, the complicated part.
+    logger.debug("Using OAuth with Basic")
+    try:
+        basic_auth = base64.b64decode(auth_blob).decode()
+        user, password = basic_auth.strip().split(":")
+    except Exception as e:
+        msg = f"invalid Basic auth string: {str(e)}"
+        raise InvalidRequestException(msg)
+    if password == "x-oauth-basic":
+        return user
+    elif user == "x-oauth-basic":
+        return password
+    else:
+        logger.info(
+            "Neither username nor password in HTTP Basic is x-oauth-basic,"
+            " assuming handle or token is username"
+        )
+        return user
+
+
+def unauthorized(
+    request: web.Request, challenge: AuthChallenge, error: str,
+) -> web.HTTPException:
+    """Construct exception for a 401 response (403 for AJAX).
+
+    Parameters
+    ----------
+    request : `aiohttp.web.Request`
+        The incoming request.
+    challenge : `AuthChallenge`
+        The challenge used to construct the WWW-Authenticate header.
+    error : `str`
+        The error message to use as the body of the message.
+
+    Returns
+    -------
+    exception : `aiohttp.web.HTTPException`
+        The exception to raise, either HTTPForbidden (for AJAX) or
+        HTTPUnauthorized.
+
+    Notes
+    -----
+    If the request contains X-Requested-With: XMLHttpRequest, return 403
+    rather than 401.  The presence of this header indicates an AJAX request,
+    which in turn means that the request is not under full control of the
+    browser window.  The redirect ingress-nginx will send will therefore not
+    result in the user going to the authentication provider properly, but may
+    result in a spurious request from background AJAX that cannot be
+    completed.  That, in turn, can cause unnecessary load on the
+    authentication provider and may result in rate limiting.
+
+    Checking for this header does not catch all requests that are pointless to
+    redirect (image and CSS requests, for instance), and not all AJAX requests
+    will send the header, but every request with this header should be
+    pointless to redirect, so at least it cuts down on the noise.
+    This corresponds to the ``invalid_token`` error in RFC 6750: "The access
+    token provided is expired, revoked, malformed, or invalid for other
+    reasons.  The string form of this exception is suitable for use as the
+    ``error_description`` attribute of a ``WWW-Authenticate`` header.
+    """
+    headers = {"WWW-Authenticate": challenge.as_header()}
+
+    requested_with = request.headers.get("X-Requested-With")
+    if requested_with and requested_with.lower() == "xmlhttprequest":
+        return web.HTTPForbidden(headers=headers, reason=error, text=error)
+    else:
+        return web.HTTPUnauthorized(headers=headers, reason=error, text=error)
 
 
 def maybe_reissue_token(

--- a/src/gafaelfawr/handlers/util.py
+++ b/src/gafaelfawr/handlers/util.py
@@ -2,239 +2,98 @@
 
 from __future__ import annotations
 
-import base64
-from functools import wraps
+import re
+from dataclasses import dataclass
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 import jwt
 from aiohttp import web
-from aiohttp_session import get_session
 
-from gafaelfawr.session import SessionHandle
 from gafaelfawr.tokens import Token
 
 if TYPE_CHECKING:
-    from gafaelfawr.config import Config
     from gafaelfawr.factory import ComponentFactory
     from gafaelfawr.tokens import VerifiedToken
-    from logger import Logger
-    from typing import Any, Awaitable, Callable, Optional
+    from typing import Optional
 
-    Route = Callable[[web.Request], Awaitable[Any]]
-    AuthenticatedRoute = Callable[[web.Request, VerifiedToken], Awaitable[Any]]
+__all__ = [
+    "AuthChallenge",
+    "AuthError",
+    "AuthType",
+    "InvalidTokenException",
+    "verify_token",
+]
 
-__all__ = ["authenticated"]
+
+class AuthType(Enum):
+    """Authentication types for the WWW-Authenticate header."""
+
+    Basic = auto()
+    Bearer = auto()
 
 
-def authenticated(route: AuthenticatedRoute) -> Route:
-    """Decorator to mark a route as requiring authentication.
+class AuthError(Enum):
+    """Valid authentication errors for a WWW-Authenticate header.
 
-    The authentication token is extracted from the incoming request and
-    verified, and then passed as an additional parameter to the wrapped
-    function.  If the token is missing or invalid, throws an unauthorized
-    exception.
-
-    Parameters
-    ----------
-    route : `typing.Callable`
-        The route that requires authentication.  The token is extracted from
-        the incoming request headers, verified, and then passed as a second
-        argument of type `gafaelfawr.tokens.VerifiedToken` to the route.
-
-    Returns
-    -------
-    response : `typing.Callable`
-        The decorator generator.
-
-    Raises
-    ------
-    aiohttp.web.HTTPException
-        If no token is present or the token cannot be verified.
+    Defined in RFC 6750.
     """
 
-    @wraps(route)
-    async def authenticated_route(request: web.Request) -> Any:
-        logger: Logger = request["safir/logger"]
-
-        try:
-            token = await get_token_from_request(request)
-            if not token:
-                logger.info("No token found, returning unauthorized")
-                raise unauthorized(request, "Unable to find token")
-        except jwt.PyJWTError as e:
-            logger.exception("Failed to authenticate token")
-            raise unauthorized(request, "Invalid token", str(e))
-
-        return await route(request, token)
-
-    return authenticated_route
+    invalid_request = auto()
+    invalid_token = auto()
+    insufficient_scope = auto()
 
 
-async def get_token_from_request(
-    request: web.Request,
-) -> Optional[VerifiedToken]:
-    """From the request, find the token we need.
+@dataclass
+class AuthChallenge:
+    """Represents the components of a WWW-Authenticate header."""
 
-    It may be an Authorization header of type ``bearer``, in one of type
-    ``basic`` for clients that don't support OAuth 2, or in the session cookie
-    for web clients in cases where oauth2_proxy is not in use.
+    auth_type: AuthType
+    """The authentication type (the first part of the header)."""
 
-    Parameters
-    ----------
-    request : `aiohttp.web.Request`
-        The incoming request.
+    realm: str
+    """The value of the realm attribute."""
 
-    Returns
-    -------
-    token : `gafaelfawr.tokens.VerifiedToken`, optional
-        The token if found, otherwise None.
+    error: Optional[AuthError] = None
+    """The value of the error attribute if present."""
 
-    Raises
-    ------
-    aiohttp.web.HTTPException
-        A token was provided but it could not be verified.
+    error_description: Optional[str] = None
+    """The value of the error description attribute if present."""
+
+    scope: Optional[str] = None
+    """The value of the scope attribute if present."""
+
+    def as_header(self) -> str:
+        """Construct the WWW-Authenticate header for this challenge.
+
+        Returns
+        -------
+        header : `str`
+            Contents of the WWW-Authenticate header.
+        """
+        if self.auth_type == AuthType.Basic or not self.error:
+            return f'{self.auth_type.name} realm="{self.realm}"'
+
+        error_description = self.error_description
+        if error_description:
+            # Strip invalid characters from the description.
+            error_description = re.sub(r'["\\]', "", error_description)
+        info = f'realm="{self.realm}", error="{self.error.name}"'
+        if error_description:
+            info += f', error_description="{error_description}"'
+        if self.scope:
+            info += f', scope="{self.scope}"'
+        return f"{self.auth_type.name} {info}"
+
+
+class InvalidTokenException(Exception):
+    """The provided token was invalid.
+
+    This corresponds to the ``invalid_token`` error in RFC 6750: "The access
+    token provided is expired, revoked, malformed, or invalid for other
+    reasons.  The string form of this exception is suitable for use as the
+    ``error_description`` attribute of a ``WWW-Authenticate`` header.
     """
-    factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
-    logger: Logger = request["safir/logger"]
-
-    # Prefer X-Auth-Request-Token if set.  This is set by the /auth endpoint.
-    if request.headers.get("X-Auth-Request-Token"):
-        logger.debug("Found token in X-Auth-Request-Token")
-        return verify_token(request, request.headers["X-Auth-Request-Token"])
-
-    # Failing that, check the session.  Use it if available.  This needs to
-    # happen before checking the Authorization header, since JupyterHub will
-    # set its own Authorization header in its JavaScript calls but we won't be
-    # able to extract a token from that.
-    session = await get_session(request)
-    handle_str = session.get("handle")
-    if handle_str:
-        logger.debug("Found valid handle in session")
-        handle = SessionHandle.from_str(handle_str)
-        session_store = factory.create_session_store(request)
-        auth_session = await session_store.get_session(handle)
-        if auth_session:
-            return auth_session.token
-
-    # No session or existing authentication header.  Try the Authorization
-    # header.  This case is used by API calls from clients.  If we got a
-    # session handle, convert it to a token.  Otherwise, if we got a token,
-    # verify it.
-    handle_or_token = parse_authorization(request)
-    if not handle_or_token:
-        return None
-    elif handle_or_token.startswith("gsh-"):
-        handle = SessionHandle.from_str(handle_or_token)
-        session_store = factory.create_session_store(request)
-        auth_session = await session_store.get_session(handle)
-        return auth_session.token if auth_session else None
-    else:
-        return verify_token(request, handle_or_token)
-
-
-def parse_authorization(request: web.Request) -> Optional[str]:
-    """Find a handle or token in the Authorization header.
-
-    Supports either ``Bearer`` or ``Basic`` authorization types.
-
-    Parameters
-    ----------
-    request : `aiohttp.web.Request`
-        The incoming request.
-
-    Returns
-    -------
-    handle_or_token : `str` or `None`
-        The handle or token if one was found, otherwise None.
-
-    Notes
-    -----
-    A Basic Auth authentication string is normally a username and a password
-    separated by colon and then base64-encoded.  Support a username of the
-    token (or session handle) and a password of ``x-oauth-basic``, or a
-    username of ``x-oauth-basic`` and a password of the token (or session
-    handle).  If neither is the case, assume the token or session handle is
-    the username.
-    """
-    logger: Logger = request["safir/logger"]
-
-    # Parse the header and handle Bearer.
-    header = request.headers.get("Authorization")
-    if not header or " " not in header:
-        return None
-    auth_type, auth_blob = header.split(" ")
-    if auth_type.lower() == "bearer":
-        return auth_blob
-    elif auth_type.lower() != "basic":
-        logger.debug("Ignoring unknown Authorization type %s", auth_type)
-        return None
-
-    # Basic, the complicated part.
-    logger.debug("Using OAuth with Basic")
-    try:
-        basic_auth = base64.b64decode(auth_blob).decode()
-        user, password = basic_auth.strip().split(":")
-    except Exception as e:
-        logger.warning("Invalid Basic auth string: %s", str(e))
-        return None
-    if password == "x-oauth-basic":
-        return user
-    elif user == "x-oauth-basic":
-        return password
-    else:
-        logger.info(
-            "Neither username nor password in HTTP Basic is x-oauth-basic,"
-            " assuming handle or token is username"
-        )
-        return user
-
-
-def unauthorized(
-    request: web.Request, error: str, message: str = ""
-) -> web.HTTPException:
-    """Construct exception for a 401 response (403 for AJAX).
-
-    Parameters
-    ----------
-    request : `aiohttp.web.Request`
-        The incoming request.
-    error : `str`
-        The error message to use as the body of the message and the error
-        parameter in the WWW-Authenticate header.
-    message : `str`, optional
-        The error description for the WWW-Authetnicate header.
-
-    Returns
-    -------
-    exception : `aiohttp.web.HTTPException`
-        Exception to throw.
-
-    Notes
-    -----
-    If the request contains X-Requested-With: XMLHttpRequest, return 403
-    rather than 401.  The presence of this header indicates an AJAX request,
-    which in turn means that the request is not under full control of the
-    browser window.  The redirect ingress-nginx will send will therefore not
-    result in the user going to the authentication provider properly, but may
-    result in a spurious request from background AJAX that cannot be
-    completed.  That, in turn, can cause unnecessary load on the
-    authentication provider and may result in rate limiting.
-
-    Checking for this header does not catch all requests that are pointless to
-    redirect (image and CSS requests, for instance), and not all AJAX requests
-    will send the header, but every request with this header should be
-    pointless to redirect, so at least it cuts down on the noise.
-    """
-    config: Config = request.config_dict["gafaelfawr/config"]
-
-    requested_with = request.headers.get("X-Requested-With")
-    if requested_with and requested_with.lower() == "xmlhttprequest":
-        return web.HTTPForbidden(reason=error, text=error)
-    else:
-        realm = config.realm
-        info = f'realm="{realm}",error="{error}",error_description="{message}"'
-        headers = {"WWW-Authenticate": f"Bearer {info}"}
-        return web.HTTPUnauthorized(headers=headers, reason=error, text=error)
 
 
 def verify_token(request: web.Request, encoded_token: str) -> VerifiedToken:
@@ -254,17 +113,16 @@ def verify_token(request: web.Request, encoded_token: str) -> VerifiedToken:
 
     Raises
     ------
-    aiohttp.web.HTTPException
+    InvalidTokenException
         If the token could not be verified.
+    gafaelfawr.verify.MissingClaimsException
+        If the token is missing required claims.
     """
     factory: ComponentFactory = request.config_dict["gafaelfawr/factory"]
-    logger: Logger = request["safir/logger"]
 
     token = Token(encoded=encoded_token)
     token_verifier = factory.create_token_verifier(request)
     try:
         return token_verifier.verify_internal_token(token)
-    except Exception as e:
-        error = f"Invalid token: {str(e)}"
-        logger.warning("%s", error)
-        raise web.HTTPForbidden(reason=error, text=error)
+    except jwt.InvalidTokenError as e:
+        raise InvalidTokenException(str(e))

--- a/tests/handlers/tokens_test.py
+++ b/tests/handlers/tokens_test.py
@@ -23,11 +23,17 @@ async def test_tokens_invalid_auth(
     create_test_setup: SetupTestCallable,
 ) -> None:
     setup = await create_test_setup()
+    token = setup.create_token()
 
     r = await setup.client.get(
         "/auth/tokens", headers={"X-Auth-Request-Token": "foo"}
     )
-    assert r.status == 403
+    assert r.status == 401
+
+    r = await setup.client.get(
+        "/auth/tokens", headers={"X-Auth-Request-Token": token.encoded + "xxx"}
+    )
+    assert r.status == 401
 
 
 async def test_tokens_empty_list(create_test_setup: SetupTestCallable) -> None:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from gafaelfawr.config import Config
     from gafaelfawr.factory import ComponentFactory
     from gafaelfawr.tokens import VerifiedToken
-    from typing import Awaitable, Callable, List, Optional
+    from typing import Awaitable, Callable, List, Optional, Union
 
 
 class SetupTest:
@@ -74,7 +74,7 @@ class SetupTest:
         return handle
 
     def create_token(
-        self, *, groups: Optional[List[str]] = None, **claims: str
+        self, *, groups: Optional[List[str]] = None, **claims: Union[str, int]
     ) -> VerifiedToken:
         """Create a signed internal token.
 
@@ -82,7 +82,7 @@ class SetupTest:
         ----------
         groups : List[`str`], optional
             Group memberships the generated token should have.
-        **claims : `str`, optional
+        **claims : Union[`str`, `int`], optional
             Other claims to set or override in the token.
 
         Returns
@@ -90,7 +90,9 @@ class SetupTest:
         token : `gafaelfawr.tokens.VerifiedToken`
             The generated token.
         """
-        return create_test_token(self.config, groups=groups, **claims)
+        return create_test_token(
+            self.config, groups=groups, kid="some-kid", **claims
+        )
 
     def create_oidc_token(
         self, *, groups: Optional[List[str]] = None, **claims: str

--- a/tests/support/tokens.py
+++ b/tests/support/tokens.py
@@ -12,17 +12,17 @@ from gafaelfawr.tokens import VerifiedToken
 
 if TYPE_CHECKING:
     from gafaelfawr.config import Config
-    from typing import Any, Dict, List, Optional
+    from typing import Any, Dict, List, Optional, Union
 
 __all__ = ["create_oidc_test_token", "create_test_token"]
 
 
 def create_test_token(
     config: Config,
-    *,
     groups: Optional[List[str]] = None,
+    *,
     kid: str = "some-kid",
-    **claims: str,
+    **claims: Union[str, int],
 ) -> VerifiedToken:
     """Create a signed token using the configured test issuer.
 
@@ -37,7 +37,7 @@ def create_test_token(
         Group memberships the generated token should have.
     kid : str, optional
         The kid to set in the envelope.  Defaults to ``some-kid``.
-    **claims : `str`, optional
+    **claims : Union[`str`, `int`], optional
         Other claims to set or override in the token.
 
     Returns


### PR DESCRIPTION
Allow the authentication type for the challenge in WWW-Authenticate
to be configured via the auth_type parameter to the /auth route.
Some applications will want to present a Basic challenge instead.

Bring the challenges into compliance with RFC 6750 when returning
a Bearer challenge.  This specifically means no longer using a
free-form error and instead using the registered error types,
returning 400 instead of 401 in cases where the header could not
be parsed, and including a challenge with 400 and 403 responses.

Separate authenticated route handling for the tokens web interface
from the /auth handling.  The former only needs to know about the
API exported by ingress-nginx with the /auth handler, and mixing
that into the full parsing and return codes for the /auth handler
was confusing and fragile.  This resulted in a lot of code
reshuffling to move code only used from one module into that module.

Wrap authentication challenges in some data types to make the code
a bit more robust and readable.