### PR TITLE
[DM-24662] Document cilogin.login_params Helm parameter

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -136,6 +136,11 @@ To use that chart, you will need to provide a ``values.yaml`` file with the foll
     The full redirect URL for CILogon if using CILogon as the identity provider.
     Set this if you need to change the redirect URL to the ``/oauth2/callback`` route instead of the ``/login`` route.
 
+``cilogon.login_params``
+    A mapping of additional parameters to send to the CILogon authorize route.
+    Can be used to set parameters like ``skin`` or ``selected_idp``.
+    See the `CILogon OIDC documentation <https://www.cilogon.org/oidc>`__ for more information.
+
 ``known_scopes``
     Mapping of scope names to descriptions.
     This is used to populate the new token creation page.


### PR DESCRIPTION
The Helm chart now supports setting cilogin.login_params to pass
additional options to CILogon.